### PR TITLE
feat: AXL P2P agent communication layer

### DIFF
--- a/src/agents/agent-runner.ts
+++ b/src/agents/agent-runner.ts
@@ -1,0 +1,103 @@
+import { createRequire } from "module";
+import { config } from "dotenv";
+
+config();
+
+const require = createRequire(import.meta.url);
+const { createZGComputeNetworkBroker } = require("@0glabs/0g-serving-broker");
+const { ethers } = require("ethers");
+
+import { AXLClient, type AXLNodeConfig } from "./axl-client.js";
+import { parseAgentMessage, type ResponseMessage, type QueryMessage } from "./dispatcher.js";
+import { callModel } from "../consensus/models.js";
+import type { ModelConfig } from "../types/index.js";
+
+export interface AgentConfig {
+  name: string;
+  node: AXLNodeConfig;
+  model: ModelConfig;
+  network: "testnet" | "mainnet";
+}
+
+export async function runAgent(agentConfig: AgentConfig): Promise<void> {
+  const { name, node, model, network } = agentConfig;
+
+  const rpcUrl =
+    network === "mainnet"
+      ? "https://evmrpc.0g.ai"
+      : "https://evmrpc-testnet.0g.ai";
+
+  const privateKey = process.env.OG_PRIVATE_KEY;
+  if (!privateKey) throw new Error("OG_PRIVATE_KEY not set");
+
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const wallet = new ethers.Wallet(privateKey, provider);
+  const broker = await createZGComputeNetworkBroker(wallet);
+
+  const client = new AXLClient(node);
+  const topology = await client.topology();
+
+  console.log(`[${name}] Agent started`);
+  console.log(`  Node:     ${node.host}:${node.port}`);
+  console.log(`  Peer ID:  ${topology.ourPublicKey}`);
+  console.log(`  Model:    ${model.name}`);
+  console.log(`  Peers:    ${topology.peers.length}`);
+  console.log(`  Listening for queries...\n`);
+
+  while (true) {
+    try {
+      const messages = await client.recv();
+
+      for (const msg of messages) {
+        const parsed = parseAgentMessage(msg.data ?? JSON.stringify(msg));
+        if (parsed?.type !== "query") continue;
+
+        const query = parsed as QueryMessage;
+        console.log(`[${name}] Received query: "${query.query.slice(0, 80)}..."`);
+        console.log(`  Request ID: ${query.requestId}`);
+
+        try {
+          const result = await callModel(broker, model, query.query);
+
+          const response: ResponseMessage = {
+            type: "response",
+            requestId: query.requestId,
+            model: result.model,
+            provider: result.provider,
+            content: result.content,
+            chatID: result.chatID,
+            teeVerified: result.teeVerified,
+            teeSignature: result.teeSignature,
+            timestamp: new Date().toISOString(),
+          };
+
+          await client.send(msg.from, JSON.stringify(response));
+          console.log(`[${name}] Response sent (TEE verified: ${result.teeVerified})\n`);
+        } catch (err: any) {
+          console.error(`[${name}] Inference failed: ${err.message}\n`);
+        }
+      }
+    } catch {
+      // recv polling failure — retry
+    }
+
+    await new Promise((r) => setTimeout(r, 500));
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const port = parseInt(process.argv[2] || "9002");
+  const modelName = process.argv[3] || "qwen/qwen-2.5-7b-instruct";
+  const providerAddr = process.argv[4] || "0xa48f01287233509FD694a22Bf840225062E67836";
+  const agentName = process.argv[5] || `agent-${port}`;
+
+  runAgent({
+    name: agentName,
+    node: { host: "http://127.0.0.1", port },
+    model: { name: modelName, provider: providerAddr },
+    network: "testnet",
+  }).catch((err) => {
+    console.error(`Fatal: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/src/agents/axl-client.ts
+++ b/src/agents/axl-client.ts
@@ -1,0 +1,81 @@
+export interface AXLNodeConfig {
+  host: string;
+  port: number;
+}
+
+export interface AXLTopology {
+  ourPublicKey: string;
+  peers: { publicKey: string; address: string }[];
+}
+
+export interface AXLMessage {
+  from: string;
+  data: string;
+}
+
+export class AXLClient {
+  private baseUrl: string;
+
+  constructor(config: AXLNodeConfig) {
+    this.baseUrl = `${config.host}:${config.port}`;
+  }
+
+  async send(destinationPeerId: string, message: string): Promise<void> {
+    const response = await fetch(`${this.baseUrl}/send`, {
+      method: "POST",
+      headers: {
+        "X-Destination-Peer-Id": destinationPeerId,
+        "Content-Type": "application/json",
+      },
+      body: message,
+    });
+
+    if (!response.ok) {
+      throw new Error(`AXL send failed (HTTP ${response.status})`);
+    }
+  }
+
+  async recv(): Promise<AXLMessage[]> {
+    const response = await fetch(`${this.baseUrl}/recv`);
+
+    if (!response.ok) {
+      throw new Error(`AXL recv failed (HTTP ${response.status})`);
+    }
+
+    const body = await response.text();
+    if (!body || body.trim() === "") return [];
+
+    try {
+      const parsed = JSON.parse(body);
+      return Array.isArray(parsed) ? parsed : [parsed];
+    } catch {
+      return [{ from: "unknown", data: body }];
+    }
+  }
+
+  async topology(): Promise<AXLTopology> {
+    const response = await fetch(`${this.baseUrl}/topology`);
+
+    if (!response.ok) {
+      throw new Error(`AXL topology failed (HTTP ${response.status})`);
+    }
+
+    const data = await response.json();
+    return {
+      ourPublicKey: data.our_public_key ?? data.ourPublicKey ?? "",
+      peers: (data.peers ?? []).map((p: any) => ({
+        publicKey: p.public_key ?? p.publicKey ?? "",
+        address: p.address ?? "",
+      })),
+    };
+  }
+
+  async isHealthy(): Promise<boolean> {
+    try {
+      await this.topology();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/agents/dispatcher.ts
+++ b/src/agents/dispatcher.ts
@@ -1,0 +1,90 @@
+import { AXLClient } from "./axl-client.js";
+
+export interface QueryMessage {
+  type: "query";
+  requestId: string;
+  query: string;
+  timestamp: string;
+}
+
+export interface ResponseMessage {
+  type: "response";
+  requestId: string;
+  model: string;
+  provider: string;
+  content: string;
+  chatID: string;
+  teeVerified: boolean | null;
+  teeSignature: any;
+  timestamp: string;
+}
+
+export type AgentMessage = QueryMessage | ResponseMessage;
+
+export function createQueryMessage(query: string): QueryMessage {
+  return {
+    type: "query",
+    requestId: `req-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    query,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function parseAgentMessage(raw: string): AgentMessage | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed.type === "query" || parsed.type === "response") return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function dispatchQuery(
+  client: AXLClient,
+  peerIds: string[],
+  query: string
+): Promise<QueryMessage> {
+  const message = createQueryMessage(query);
+  const payload = JSON.stringify(message);
+
+  await Promise.all(
+    peerIds.map((peerId) => client.send(peerId, payload))
+  );
+
+  return message;
+}
+
+export async function collectResponses(
+  client: AXLClient,
+  requestId: string,
+  expectedCount: number,
+  timeoutMs: number = 30000,
+  pollIntervalMs: number = 500
+): Promise<ResponseMessage[]> {
+  const responses: ResponseMessage[] = [];
+  const deadline = Date.now() + timeoutMs;
+
+  while (responses.length < expectedCount && Date.now() < deadline) {
+    try {
+      const messages = await client.recv();
+      for (const msg of messages) {
+        const parsed = parseAgentMessage(msg.data ?? JSON.stringify(msg));
+        if (
+          parsed?.type === "response" &&
+          parsed.requestId === requestId
+        ) {
+          responses.push(parsed);
+        }
+      }
+    } catch {
+      // recv can fail transiently
+    }
+
+    if (responses.length < expectedCount) {
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
+    }
+  }
+
+  return responses;
+}

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -1,0 +1,149 @@
+import { createRequire } from "module";
+import { config } from "dotenv";
+
+config();
+
+const require = createRequire(import.meta.url);
+const { ethers } = require("ethers");
+
+import { AXLClient, type AXLNodeConfig } from "./axl-client.js";
+import { dispatchQuery, collectResponses, type ResponseMessage } from "./dispatcher.js";
+import { buildConsensus } from "../consensus/comparator.js";
+import { buildReport, formatReport } from "../consensus/report.js";
+import { storeReport } from "../storage/store.js";
+import type { ModelResponse, PoTReport } from "../types/index.js";
+
+export interface OrchestratorConfig {
+  coordinatorNode: AXLNodeConfig;
+  agentPeerIds: string[];
+  network: "testnet" | "mainnet";
+  store: boolean;
+}
+
+function responseMessageToModelResponse(msg: ResponseMessage): ModelResponse {
+  return {
+    model: msg.model,
+    provider: msg.provider,
+    content: msg.content,
+    chatID: msg.chatID,
+    teeSignature: msg.teeSignature ?? null,
+    teeVerified: msg.teeVerified,
+    attestationUrl: "",
+    timestamp: msg.timestamp,
+    timings: { inference: 0, verification: 0, signatureFetch: 0, total: 0 },
+  };
+}
+
+export async function runP2PConsensus(
+  query: string,
+  orchestratorConfig: OrchestratorConfig
+): Promise<PoTReport> {
+  const { coordinatorNode, agentPeerIds, network, store } = orchestratorConfig;
+
+  const rpcUrl =
+    network === "mainnet"
+      ? "https://evmrpc.0g.ai"
+      : "https://evmrpc-testnet.0g.ai";
+
+  const client = new AXLClient(coordinatorNode);
+  const topology = await client.topology();
+
+  console.log(`\nCoordinator: ${coordinatorNode.host}:${coordinatorNode.port}`);
+  console.log(`Peer ID:     ${topology.ourPublicKey}`);
+  console.log(`Agents:      ${agentPeerIds.length}`);
+  console.log(`Network:     ${network}\n`);
+
+  // Step 1: Dispatch query to all agent peers
+  console.log(`Dispatching query to ${agentPeerIds.length} agent(s) over AXL P2P...`);
+  const t0 = performance.now();
+  const queryMsg = await dispatchQuery(client, agentPeerIds, query);
+  console.log(`  Request ID: ${queryMsg.requestId}\n`);
+
+  // Step 2: Collect TEE-verified responses
+  console.log("Waiting for agent responses...");
+  const responseMessages = await collectResponses(
+    client,
+    queryMsg.requestId,
+    agentPeerIds.length,
+    60000
+  );
+  const tResponses = performance.now();
+  console.log(
+    `Received ${responseMessages.length}/${agentPeerIds.length} responses in ${((tResponses - t0) / 1000).toFixed(1)}s\n`
+  );
+
+  if (responseMessages.length === 0) {
+    throw new Error("No agent responses received");
+  }
+
+  const responses = responseMessages.map(responseMessageToModelResponse);
+
+  // Step 3: Build consensus
+  console.log("Building consensus...");
+  const consensus = buildConsensus(responses);
+  const tConsensus = performance.now();
+  console.log(
+    `Consensus: ${(consensus.agreementScore * 100).toFixed(1)}% agreement (${(tConsensus - tResponses).toFixed(0)}ms)\n`
+  );
+
+  // Step 4: Build report
+  const report = buildReport(query, responses, consensus);
+
+  // Step 5: Store on 0G
+  if (store) {
+    const privateKey = process.env.OG_PRIVATE_KEY;
+    if (privateKey) {
+      console.log("Storing PoT Report on 0G Storage...");
+      try {
+        const provider = new ethers.JsonRpcProvider(rpcUrl);
+        const wallet = new ethers.Wallet(privateKey, provider);
+        const { rootHash } = await storeReport(report, rpcUrl, wallet);
+        report.storedOn = `0g://${rootHash}`;
+        console.log(`  Stored: ${report.storedOn}\n`);
+      } catch (err: any) {
+        console.error(`  Storage failed: ${err.message}\n`);
+      }
+    }
+  }
+
+  console.log(formatReport(report));
+
+  const totalTime = performance.now() - t0;
+  console.log(`\nTotal P2P pipeline: ${(totalTime / 1000).toFixed(1)}s`);
+
+  return report;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const query =
+    process.argv[2] ||
+    "What are the top 3 risks of lending ETH on Aave v3 right now?";
+
+  const peerIds = (process.argv[3] || "").split(",").filter(Boolean);
+
+  if (peerIds.length === 0) {
+    console.error("Usage: npx tsx orchestrator.ts <query> <peer1,peer2,...>");
+    console.error("  Get peer IDs from: curl http://127.0.0.1:9002/topology");
+    process.exit(1);
+  }
+
+  console.log("═".repeat(60));
+  console.log("  PROOF OF THOUGHT — P2P Consensus");
+  console.log("═".repeat(60));
+  console.log(`\nQuery: "${query}"`);
+
+  runP2PConsensus(query, {
+    coordinatorNode: { host: "http://127.0.0.1", port: 9002 },
+    agentPeerIds: peerIds,
+    network: "testnet",
+    store: true,
+  })
+    .then((report) => {
+      console.log(`\nReport ID: ${report.id}`);
+      console.log(`PoT Hash:  ${report.potHash}`);
+    })
+    .catch((err) => {
+      console.error(`\nFatal: ${err.message}`);
+      process.exit(1);
+    });
+}

--- a/src/prototype/07-axl-smoke-test.ts
+++ b/src/prototype/07-axl-smoke-test.ts
@@ -1,0 +1,77 @@
+import { AXLClient } from "../agents/axl-client.js";
+import { createQueryMessage, parseAgentMessage } from "../agents/dispatcher.js";
+
+const NODE_A_KEY = process.env.AXL_NODE_A_KEY || "";
+const NODE_B_KEY = process.env.AXL_NODE_B_KEY || "";
+
+async function main() {
+  const clientA = new AXLClient({ host: "http://127.0.0.1", port: 9002 });
+  const clientB = new AXLClient({ host: "http://127.0.0.1", port: 9003 });
+
+  console.log("=== AXL P2P Smoke Test ===\n");
+
+  const topoA = await clientA.topology();
+  console.log(`Node A: ${topoA.ourPublicKey.slice(0, 16)}... (${topoA.peers.length} peers)`);
+  const topoB = await clientB.topology();
+  console.log(`Node B: ${topoB.ourPublicKey.slice(0, 16)}... (${topoB.peers.length} peers)`);
+
+  const peerB = NODE_B_KEY || topoB.ourPublicKey;
+  const peerA = NODE_A_KEY || topoA.ourPublicKey;
+
+  // 1. Send query A → B
+  const query = createQueryMessage("What are the risks of lending ETH on Aave v3?");
+  console.log(`\n[1] Sending query A → B (${query.requestId})...`);
+  await clientA.send(peerB, JSON.stringify(query));
+  console.log("    Sent!");
+
+  // 2. Recv on B
+  await new Promise((r) => setTimeout(r, 1000));
+  console.log("\n[2] Receiving on B...");
+  const messages = await clientB.recv();
+  console.log(`    Got ${messages.length} message(s)`);
+
+  if (messages.length > 0) {
+    const raw = messages[0].data ?? JSON.stringify(messages[0]);
+    const parsed = parseAgentMessage(raw);
+    if (parsed?.type === "query") {
+      console.log(`    ✓ Query received: "${parsed.query.slice(0, 50)}..."`);
+      console.log(`    ✓ Request ID: ${parsed.requestId}`);
+    }
+  }
+
+  // 3. Send response B → A
+  const response = {
+    type: "response" as const,
+    requestId: query.requestId,
+    model: "test-model",
+    provider: "0xTest",
+    content: "The top risks are smart contract vulnerabilities and liquidation cascades.",
+    chatID: "chat-test",
+    teeVerified: true,
+    teeSignature: null,
+    timestamp: new Date().toISOString(),
+  };
+  console.log("\n[3] Sending response B → A...");
+  await clientB.send(peerA, JSON.stringify(response));
+  console.log("    Sent!");
+
+  // 4. Recv on A
+  await new Promise((r) => setTimeout(r, 1000));
+  console.log("\n[4] Receiving on A...");
+  const replies = await clientA.recv();
+  console.log(`    Got ${replies.length} message(s)`);
+
+  if (replies.length > 0) {
+    const raw = replies[0].data ?? JSON.stringify(replies[0]);
+    const parsed = parseAgentMessage(raw);
+    if (parsed?.type === "response") {
+      console.log(`    ✓ Response from: ${parsed.model}`);
+      console.log(`    ✓ TEE verified: ${parsed.teeVerified}`);
+      console.log(`    ✓ Content: "${parsed.content.slice(0, 60)}..."`);
+    }
+  }
+
+  console.log("\n✓ Bidirectional P2P messaging works over AXL!");
+}
+
+main().catch(console.error);

--- a/tests/axl-client.test.ts
+++ b/tests/axl-client.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AXLClient } from "../src/agents/axl-client.js";
+
+const NODE = { host: "http://127.0.0.1", port: 9002 };
+
+describe("AXLClient", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  describe("send", () => {
+    it("sends a message with correct headers", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+      const client = new AXLClient(NODE);
+
+      await client.send("peer-123", '{"type":"query","query":"test"}');
+
+      const call = vi.mocked(fetch).mock.calls[0];
+      expect(call[0]).toBe("http://127.0.0.1:9002/send");
+      expect(call[1]!.method).toBe("POST");
+      expect((call[1]!.headers as Record<string, string>)["X-Destination-Peer-Id"]).toBe("peer-123");
+      expect(call[1]!.body).toBe('{"type":"query","query":"test"}');
+    });
+
+    it("throws on HTTP error", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+      const client = new AXLClient(NODE);
+
+      await expect(client.send("peer-123", "data")).rejects.toThrow("AXL send failed (HTTP 503)");
+    });
+  });
+
+  describe("recv", () => {
+    it("returns parsed JSON array", async () => {
+      const messages = [{ from: "peer-A", data: '{"type":"response"}' }];
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify(messages),
+      }));
+      const client = new AXLClient(NODE);
+
+      const result = await client.recv();
+      expect(result).toEqual(messages);
+    });
+
+    it("returns empty array for empty body", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => "",
+      }));
+      const client = new AXLClient(NODE);
+
+      const result = await client.recv();
+      expect(result).toEqual([]);
+    });
+
+    it("wraps plain text as a message", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => "plain text message",
+      }));
+      const client = new AXLClient(NODE);
+
+      const result = await client.recv();
+      expect(result).toEqual([{ from: "unknown", data: "plain text message" }]);
+    });
+
+    it("throws on HTTP error", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+      const client = new AXLClient(NODE);
+
+      await expect(client.recv()).rejects.toThrow("AXL recv failed (HTTP 500)");
+    });
+  });
+
+  describe("topology", () => {
+    it("returns normalized topology", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          our_public_key: "0xABC",
+          peers: [{ public_key: "0xDEF", address: "tls://10.0.0.1:9001" }],
+        }),
+      }));
+      const client = new AXLClient(NODE);
+
+      const topo = await client.topology();
+      expect(topo.ourPublicKey).toBe("0xABC");
+      expect(topo.peers).toHaveLength(1);
+      expect(topo.peers[0].publicKey).toBe("0xDEF");
+    });
+
+    it("handles empty peer list", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ our_public_key: "0xABC" }),
+      }));
+      const client = new AXLClient(NODE);
+
+      const topo = await client.topology();
+      expect(topo.peers).toEqual([]);
+    });
+  });
+
+  describe("isHealthy", () => {
+    it("returns true when topology succeeds", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ our_public_key: "0xABC", peers: [] }),
+      }));
+      const client = new AXLClient(NODE);
+
+      expect(await client.isHealthy()).toBe(true);
+    });
+
+    it("returns false when topology fails", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("connection refused")));
+      const client = new AXLClient(NODE);
+
+      expect(await client.isHealthy()).toBe(false);
+    });
+  });
+});

--- a/tests/dispatcher.test.ts
+++ b/tests/dispatcher.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createQueryMessage,
+  parseAgentMessage,
+  dispatchQuery,
+  collectResponses,
+  type ResponseMessage,
+} from "../src/agents/dispatcher.js";
+import { AXLClient } from "../src/agents/axl-client.js";
+
+describe("createQueryMessage", () => {
+  it("creates a query with unique request ID", () => {
+    const msg = createQueryMessage("What are the risks?");
+    expect(msg.type).toBe("query");
+    expect(msg.query).toBe("What are the risks?");
+    expect(msg.requestId).toMatch(/^req-\d+-\w+$/);
+    expect(msg.timestamp).toBeTruthy();
+  });
+
+  it("generates different IDs each time", () => {
+    const msg1 = createQueryMessage("a");
+    const msg2 = createQueryMessage("b");
+    expect(msg1.requestId).not.toBe(msg2.requestId);
+  });
+});
+
+describe("parseAgentMessage", () => {
+  it("parses a valid query message", () => {
+    const msg = parseAgentMessage(JSON.stringify({
+      type: "query",
+      requestId: "req-1",
+      query: "test",
+      timestamp: "2026-01-01",
+    }));
+    expect(msg?.type).toBe("query");
+  });
+
+  it("parses a valid response message", () => {
+    const msg = parseAgentMessage(JSON.stringify({
+      type: "response",
+      requestId: "req-1",
+      model: "qwen",
+      content: "answer",
+    }));
+    expect(msg?.type).toBe("response");
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseAgentMessage("not json")).toBeNull();
+  });
+
+  it("returns null for unknown message types", () => {
+    expect(parseAgentMessage('{"type":"unknown"}')).toBeNull();
+  });
+});
+
+describe("dispatchQuery", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("sends query to all peers", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+    const client = new AXLClient({ host: "http://127.0.0.1", port: 9002 });
+
+    const msg = await dispatchQuery(client, ["peer-A", "peer-B"], "test query");
+
+    expect(msg.type).toBe("query");
+    expect(msg.query).toBe("test query");
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+
+    const call1 = vi.mocked(fetch).mock.calls[0];
+    expect((call1[1]!.headers as Record<string, string>)["X-Destination-Peer-Id"]).toBe("peer-A");
+
+    const call2 = vi.mocked(fetch).mock.calls[1];
+    expect((call2[1]!.headers as Record<string, string>)["X-Destination-Peer-Id"]).toBe("peer-B");
+  });
+});
+
+describe("collectResponses", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("collects matching responses", async () => {
+    const response: ResponseMessage = {
+      type: "response",
+      requestId: "req-target",
+      model: "qwen",
+      provider: "0xA",
+      content: "answer",
+      chatID: "chat-1",
+      teeVerified: true,
+      teeSignature: null,
+      timestamp: "2026-01-01",
+    };
+
+    let callCount = 0;
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          ok: true,
+          text: async () => JSON.stringify([{ from: "peer-A", data: JSON.stringify(response) }]),
+        };
+      }
+      return { ok: true, text: async () => "" };
+    }));
+
+    const client = new AXLClient({ host: "http://127.0.0.1", port: 9002 });
+    const results = await collectResponses(client, "req-target", 1, 2000, 100);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].model).toBe("qwen");
+    expect(results[0].requestId).toBe("req-target");
+  });
+
+  it("ignores responses with wrong request ID", async () => {
+    const wrongResponse: ResponseMessage = {
+      type: "response",
+      requestId: "req-OTHER",
+      model: "qwen",
+      provider: "0xA",
+      content: "wrong",
+      chatID: "chat-1",
+      teeVerified: true,
+      teeSignature: null,
+      timestamp: "2026-01-01",
+    };
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify([{ from: "peer-A", data: JSON.stringify(wrongResponse) }]),
+    }));
+
+    const client = new AXLClient({ host: "http://127.0.0.1", port: 9002 });
+    const results = await collectResponses(client, "req-target", 1, 1000, 100);
+
+    expect(results).toHaveLength(0);
+  });
+
+  it("returns partial results on timeout", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => "",
+    }));
+
+    const client = new AXLClient({ host: "http://127.0.0.1", port: 9002 });
+    const results = await collectResponses(client, "req-target", 3, 500, 100);
+
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/agents/axl-client.ts` — HTTP client wrapping AXL's `/send`, `/recv`, `/topology` endpoints
- Add `src/agents/dispatcher.ts` — query dispatch to peer agents, response collection with timeout + request ID matching
- Add `src/agents/agent-runner.ts` — standalone agent process: listens on an AXL node, receives queries, calls 0G Compute TEE inference, sends response back over P2P
- Add `src/agents/orchestrator.ts` — P2P consensus coordinator: dispatches query to N agent peers over AXL, collects TEE-verified responses, builds consensus, produces PoT Report

## How it works
```
                    AXL P2P Network
                         │
    ┌────────────────────┼────────────────────┐
    │                    │                    │
Orchestrator         Agent Alpha          Agent Beta
(port 9002)          (port 9002)          (port 9003)
    │                    │                    │
    ├──POST /send──────►│                    │
    ├──POST /send──────────────────────────►│
    │                    │                    │
    │              [TEE inference]      [TEE inference]
    │                    │                    │
    │◄──POST /send──────┤                    │
    │◄──POST /send────────────────────────┤
    │                                        
    └──► consensus → PoT Report → 0G Storage
```

## Usage
```bash
# Start agents (on separate terminals, requires AXL nodes running)
npx tsx src/agents/agent-runner.ts 9002 qwen/qwen-2.5-7b-instruct 0xa48f...
npx tsx src/agents/agent-runner.ts 9003 deepseek/deepseek-chat-v3 0x1B3A...

# Run P2P consensus
npx tsx src/agents/orchestrator.ts "What are the risks?" peer-id-A,peer-id-B
```

## Test plan
- [x] `npm test` — 76 tests pass across 9 files (20 new)
- [x] AXL client: send headers, recv parsing, topology normalization, health check
- [x] Dispatcher: message creation, parsing, dispatch to multiple peers, response collection with timeout + filtering
- [ ] Live test requires AXL nodes running (scripts/setup.py)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)