### PR TITLE
feat: x402 payment-gated PoT Report access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ KEEPERHUB_URL=https://api.keeperhub.com
 # x402 (USDC on Base Sepolia testnet)
 PRIVATE_KEY=
 X402_FACILITATOR_URL=https://x402.org/facilitator
+PAYMENT_ADDRESS=
 
 # 0G
 OG_RPC_URL=https://evmrpc-testnet.0g.ai

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useCallback, useEffect } from "react"
 import {
   ShieldCheck, CheckCircle, AlertTriangle, Network, MessageSquare,
   Search, Copy, Database, Link, Cpu, Zap, Clock, XCircle, Loader2,
-  WifiOff,
+  WifiOff, DollarSign,
 } from "lucide-react"
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001"
@@ -46,6 +46,13 @@ interface ConsensusData {
   divergences: Divergence[]
   verifiedCount: number
   totalCount: number
+}
+
+interface PaymentInfo {
+  price: string
+  network: string
+  payTo: string
+  reportUrl: string
 }
 
 interface ReportData {
@@ -117,6 +124,7 @@ export default function Dashboard() {
   const [feed, setFeed] = useState<FeedItem[]>([])
   const [consensus, setConsensus] = useState<ConsensusData | null>(null)
   const [report, setReport] = useState<ReportData | null>(null)
+  const [paymentInfo, setPaymentInfo] = useState<PaymentInfo | null>(null)
   const [proofSteps, setProofSteps] = useState<ProofStep[]>(DEFAULT_PROOF_STEPS)
   const [query, setQuery] = useState("What are the top 3 risks of lending ETH on Aave v3 right now?")
   const [running, setRunning] = useState(false)
@@ -184,6 +192,7 @@ export default function Dashboard() {
     setFeed([])
     setConsensus(null)
     setReport(null)
+    setPaymentInfo(null)
     setProofSteps(DEFAULT_PROOF_STEPS.map((s) => ({ ...s })))
     setAgents((prev) => prev.map((a) => ({ ...a, status: "idle" as const, timings: undefined })))
 
@@ -381,6 +390,14 @@ export default function Dashboard() {
             verifiedCount: r.proofChain.filter((p: any) => p.teeVerified).length,
             totalCount: r.proofChain.length,
           }))
+        }
+        if (data.paymentInfo && data.reportUrl) {
+          setPaymentInfo({
+            price: data.paymentInfo.price,
+            network: data.paymentInfo.network,
+            payTo: data.paymentInfo.payTo,
+            reportUrl: data.reportUrl,
+          })
         }
         break
 
@@ -603,6 +620,52 @@ export default function Dashboard() {
                   <div className="font-mono text-[10px] text-accent truncate">{report.storedOn}</div>
                 </>
               )}
+            </div>
+          )}
+
+          {paymentInfo && report && (
+            <div className="border-t border-border pt-3 mt-3 space-y-2">
+              <div className="flex items-center gap-2">
+                <DollarSign size={14} className="text-accent" />
+                <h3 className="text-[10px] font-semibold tracking-widest text-muted uppercase">View Full Report</h3>
+              </div>
+              <div className="rounded-lg border border-accent/20 bg-accent/[0.04] p-3 space-y-2">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-muted">Price</span>
+                  <span className="font-semibold text-emerald">{paymentInfo.price} USDC</span>
+                </div>
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-muted">Network</span>
+                  <span className="font-mono text-[10px]">{paymentInfo.network}</span>
+                </div>
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-muted">Pay to</span>
+                  <span className="font-mono text-[10px] truncate max-w-[140px]">{paymentInfo.payTo}</span>
+                </div>
+                <div className="text-[10px] text-muted mt-2">
+                  Report ID: <span className="font-mono text-accent">{report.id}</span>
+                </div>
+                <div className="mt-2 p-2 bg-background rounded border border-border">
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-[9px] text-muted uppercase tracking-wider">curl command</span>
+                    <button
+                      className="text-muted hover:text-foreground"
+                      onClick={() => navigator.clipboard?.writeText(
+                        `curl -s ${API_BASE}${paymentInfo.reportUrl}`
+                      )}
+                    >
+                      <Copy size={10} />
+                    </button>
+                  </div>
+                  <code className="text-[9px] text-accent break-all block">
+                    curl -s {API_BASE}{paymentInfo.reportUrl}
+                  </code>
+                  <div className="text-[9px] text-muted mt-1.5">
+                    Without payment header, returns HTTP 402 with payment requirements.
+                    x402-compatible clients handle payment automatically.
+                  </div>
+                </div>
+              </div>
             </div>
           )}
         </div>

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -8,8 +8,9 @@ const { createZGComputeNetworkBroker } = require("@0glabs/0g-serving-broker");
 const { ethers } = require("ethers");
 const express = require("express");
 const cors = require("cors");
+const { paymentMiddleware } = require("x402-express");
 
-import type { ModelConfig, ModelResponse } from "../types/index.js";
+import type { ModelConfig, ModelResponse, PoTReport } from "../types/index.js";
 import { callModel } from "../consensus/models.js";
 import { buildConsensus } from "../consensus/comparator.js";
 import { buildReport } from "../consensus/report.js";
@@ -18,6 +19,24 @@ import {
   registerReportOnChain,
   getRegistryAddress,
 } from "../contracts/registry.js";
+
+const reportStore = new Map<string, PoTReport>();
+
+const PAYMENT_ADDRESS =
+  process.env.PAYMENT_ADDRESS ||
+  (process.env.OG_PRIVATE_KEY
+    ? (() => {
+        try {
+          const w = new ethers.Wallet(process.env.OG_PRIVATE_KEY);
+          return w.address as string;
+        } catch {
+          return "0x0000000000000000000000000000000000000000";
+        }
+      })()
+    : "0x0000000000000000000000000000000000000000");
+
+const FACILITATOR_URL =
+  process.env.X402_FACILITATOR_URL || "https://x402.org/facilitator";
 
 const TESTNET_MODELS: ModelConfig[] = [
   {
@@ -77,6 +96,56 @@ async function getWalletInfo(network: "testnet" | "mainnet") {
 const app = express();
 app.use(cors({ origin: true }));
 app.use(express.json());
+
+app.use(
+  paymentMiddleware(
+    PAYMENT_ADDRESS,
+    {
+      "/api/report/:id": {
+        price: "$0.01",
+        network: "base-sepolia",
+        config: {
+          description: "Access to TEE-verified PoT Report",
+        },
+      },
+    },
+    { url: FACILITATOR_URL }
+  )
+);
+
+app.get("/api/reports", (_req: any, res: any) => {
+  const reports = Array.from(reportStore.entries()).map(([id, r]) => ({
+    id,
+    query: r.query,
+    timestamp: r.timestamp,
+    consensusScore: r.consensus.agreementScore,
+    modelCount: r.responses.length,
+    potHash: r.potHash,
+    storedOn: r.storedOn,
+  }));
+  res.json({ reports, paymentInfo: { price: "$0.01", network: "base-sepolia" } });
+});
+
+app.get("/api/report/:id", (req: any, res: any) => {
+  const report = reportStore.get(req.params.id);
+  if (!report) {
+    res.status(404).json({ error: "Report not found" });
+    return;
+  }
+
+  res.json({
+    report,
+    receipt: {
+      reportId: report.id,
+      potHash: report.potHash,
+      amount: "$0.01",
+      network: "base-sepolia",
+      proofChain: report.proofChain,
+      consensusScore: report.consensus.agreementScore,
+      timestamp: report.timestamp,
+    },
+  });
+});
 
 app.get("/api/status", async (_req: any, res: any) => {
   try {
@@ -257,6 +326,8 @@ app.post("/api/consensus", async (req: any, res: any) => {
       });
     }
 
+    reportStore.set(report.id, report);
+
     const totalTime = performance.now() - t0;
     sendEvent("report_complete", {
       report: {
@@ -270,6 +341,12 @@ app.post("/api/consensus", async (req: any, res: any) => {
         responses: report.responses,
       },
       totalTime,
+      reportUrl: `/api/report/${report.id}`,
+      paymentInfo: {
+        price: "$0.01",
+        network: "base-sepolia",
+        payTo: PAYMENT_ADDRESS,
+      },
     });
   } catch (err: any) {
     sendEvent("error", { message: err.message });


### PR DESCRIPTION
## Summary
- Gate `GET /api/report/:id` behind x402 micropayments ($0.01 USDC on Base Sepolia) using `x402-express` middleware
- Add `GET /api/reports` endpoint to list available reports (free, no payment required)
- Store completed PoT Reports in memory after consensus pipeline finishes
- Return full report + audit receipt (potHash, proofChain, consensusScore) on paid access
- Dashboard shows payment info panel (price, network, payTo address, curl command) after pipeline completes

## Test plan
- [x] All 76 existing tests pass (`npx vitest run`)
- [x] TypeScript build succeeds (`npm run build`)
- [ ] Start server (`npm run server`), run consensus, verify report is stored
- [ ] `curl localhost:3001/api/reports` returns report list
- [ ] `curl localhost:3001/api/report/<id>` returns HTTP 402 with payment requirements
- [ ] Dashboard displays payment info section after consensus completes

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)